### PR TITLE
Support for Destructuring Assignments and More

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ Example:
 
 ```javascript
 import * as x from 'y';
-const key = 'c';
 const {
     a, b,
     c = Math.random  // De-opt here!
@@ -188,7 +187,6 @@ Example with Object-Spread Pattern:
 
 ```javascript
 import * as x from 'y';
-const key = 'b';
 const {
     a, b,
     ...rest  // De-opt here!

--- a/README.md
+++ b/README.md
@@ -3,33 +3,33 @@
 Transforms wildcard style imports:
 
 ```javascript
-    import * as x from 'y';
-    import * as w from 'z';
-    x.a();
-    x.b();
-    console.log(Object.values(w));
+import * as x from 'y';
+import * as w from 'z';
+x.a();
+x.b();
+console.log(Object.values(w));
 ```
 
 into member style imports:
 
 ```javascript
-    import {a, b} from 'y';
-    import * as w from 'z';
-    a();
-    b();
-    console.log(Object.values(w));
+import {a, b} from 'y';
+import * as w from 'z';
+a();
+b();
+console.log(Object.values(w));
 ```
 
 (well, that would be ideal, but actually it looks more like the
 following, which is a bit simpler to implement:)
 
 ```javascript
-    import {a as _a, b as _b} from 'y';
-    import * as w from 'z';
-    var x = {a: _a, b: _b};
-    x.a();
-    x.b();
-    console.log(Object.values(w));
+import {a as _a, b as _b} from 'y';
+import * as w from 'z';
+var x = {a: _a, b: _b};
+x.a();
+x.b();
+console.log(Object.values(w));
 ```
 
 This is useful in some situations to get webpack and similar tools to
@@ -44,19 +44,41 @@ directly, then we leave the wildcard import in place.
 By default this will apply to all wildcard imports, for example with a
 .babelrc like:
 
-    {
-        "plugins": ["babel-plugin-transform-resolve-wildcard-import"]
-    }
+```json
+{
+    "plugins": ["babel-plugin-transform-resolve-wildcard-import"]
+}
+```
 
 If you only want it to apply this to certain import paths you can
-restrict the transforms with an array of regular expressions passed as
-`only`:
+restrict the transforms with an array of regular-expression patterns
+passed as `only`:
 
-    {
-        "plugins": [
-            ["babel-plugin-transform-resolve-wildcard-import", {only: [
-                "^lodash$",
-                "^\.\.?\/UI(\/(index(\.js)?)?)?$"
-            ]}]
-        ]
-    }
+```json
+{
+    "plugins": [
+        ["babel-plugin-transform-resolve-wildcard-import", { "only": [
+            "^lodash$",
+            "^\.\.?\/UI(\/(index(\.js)?)?)?$"
+        ]}]
+    ]
+}
+```
+
+If you are using Babel's programmatic options or Babel 7's JavaScript
+configuration files, real regular-expressions and functions can also
+be used with `only`:
+
+```javascript
+var mm = require("micromatch");
+
+module.exports = {
+    plugins: [
+        ["babel-plugin-transform-resolve-wildcard-import", { only: [
+            /^lodash$/i,
+            (name) => name.startsWith("lib/"),
+            mm.matcher("**/UI/index?(.js)")
+        ]}]
+    ]
+};
+```

--- a/README.md
+++ b/README.md
@@ -10,38 +10,208 @@ x.b();
 console.log(Object.values(w));
 ```
 
-into member style imports:
+Into member style imports:
 
 ```javascript
-import {a, b} from 'y';
+import { a, b } from 'y';
 import * as w from 'z';
 a();
 b();
 console.log(Object.values(w));
 ```
 
-(well, that would be ideal, but actually it looks more like the
-following, which is a bit simpler to implement:)
-
-```javascript
-import {a as _a, b as _b} from 'y';
-import * as w from 'z';
-var x = {a: _a, b: _b};
-x.a();
-x.b();
-console.log(Object.values(w));
-```
-
-This is useful in some situations to get webpack and similar tools to
+This is useful in some situations to get Webpack and similar tools to
 tree-shake better.
 
-Note: This plugin only works when the wildcard import (`x` in the
-example) is only ever used in a property access. If you use `x`
-directly, then we leave the wildcard import in place.
+## Supported Transformations
+
+### Simple Property Access
+
+This plugin can transform simple property access on the imported
+object into named-imports.
+
+Input:
+
+```javascript
+import * as x from 'y';
+x.a();
+x.b();
+```
+
+Equivalent output:
+
+```javascript
+import { a, b } from 'y';
+a();
+b();
+```
+
+### JSX Property Access
+
+This plugin can transform property access on the imported object, when
+used as tags for JSX elements, into named-imports.
+
+Input:
+
+```javascript
+import * as x from 'y';
+<x.A>Here is a text block. <x.B /></x.A>;
+```
+
+Equivalent output:
+
+```javascript
+import { A, B } from 'y';
+<A>Here is a text block. <B /></A>;
+```
+
+### Destructuring Variable Declaration
+
+This plugin can transform variable declarations via object destructuring,
+including nested patterns, into named-imports.
+
+Input:
+
+```javascript
+import * as x from 'y';
+const { a, b: { ['c']: see } } = x;
+a();
+see();
+```
+
+Equivalent output:
+
+```javascript
+import { a, b as _b } from 'y';
+const { ['c']: see } = _b;
+a();
+see();
+```
+
+This only supports destructuring properties from the imported object using
+identifiers; it will not transform if a literal or computed property is used,
+nor any other kind of pattern, such as the object-spread pattern or the array
+pattern.
+
+See the de-optimization cases below for more information.
+
+## De-optimizations
+
+### Direct Usage of the Imported Object
+
+This plugin will not transform an import if the imported object is used in any
+other way besides accessing its properties.
+
+Example:
+
+```javascript
+import * as x from 'y';
+x.a();
+console.dir(x);  // De-opt here!
+```
+
+### Reassigning the Variable of the Imported Object
+
+This plugin will not transform an import if the variable containing the
+imported object is reassigned at any point.
+
+Example:
+
+```javascript
+import * as x from 'y';
+x.a();
+x = {};  // De-opt here!
+```
+
+### Literal and Computed Property Access
+
+This plugin will not transform an import if a property of the imported object
+is accessed using bracket-syntax.
+
+Example:
+
+```javascript
+import * as x from 'y';
+x.a();
+x['b']();  // De-opt here!
+```
+
+### Destructuring with Property Patterns providing Default Values
+
+This plugin will not transform an import if a default value is provided in
+an object-property pattern of a destructuring variable declaration.
+
+Example:
+
+```javascript
+import * as x from 'y';
+const key = 'c';
+const {
+    a, b,
+    c = Math.random  // De-opt here!
+} = x;
+a();
+b();
+c();
+```
+
+Note: This restriction does not apply to nested patterns.
+
+### Destructuring with Literal and Computed Property Patterns
+
+This plugin will not transform an import if a literal or computed value is used
+in an object-property pattern of a destructuring variable declaration.
+
+Example:
+
+```javascript
+import * as x from 'y';
+const key = 'c';
+const {
+    a, b,
+    [key]: see  // De-opt here!
+} = x;
+a();
+b();
+see();
+```
+
+Note: This restriction does not apply to nested patterns.
+
+### Destructuring with Non-Property Patterns
+
+This plugin will not transform an import if the object-spread pattern, the
+array pattern, or any other type of non-property pattern are used in a
+destructuring variable declaration.
+
+Example with Object-Spread Pattern:
+
+```javascript
+import * as x from 'y';
+const key = 'b';
+const {
+    a, b,
+    ...rest  // De-opt here!
+} = x;
+a();
+b();
+rest.c();
+```
+
+Example with Array Pattern:
+
+```javascript
+import * as x from 'y';
+const [a, b] = x;  // De-opt here!
+a();
+b();
+```
+
+Note: This restriction does not apply to nested patterns.
 
 ## Options
 
-By default this will apply to all wildcard imports, for example with a
+By default this will apply to all wildcard imports; for example, with a
 .babelrc like:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ passed as `only`:
     "plugins": [
         ["babel-plugin-transform-resolve-wildcard-import", { "only": [
             "^lodash$",
-            "^\.\.?\/UI(\/(index(\.js)?)?)?$"
+            "^\\.\\.?\/UI(\/(index(\\.js)?)?)?$"
         ]}]
     ]
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "babel-core": "^6.20.0",
     "babel-plugin-syntax-jsx": "^6.18.0",
+    "babel-plugin-transform-es2015-destructuring": "^6.23.0",
     "babel-plugin-transform-export-extensions": "^6.22.0",
     "mocha": "3.4.2"
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "George Pittarelli <g@gjp.cc>",
   "license": "MIT",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.20.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "url": "https://github.com/gpittarelli/babel-plugin-transform-resolve-wildcard-import.git"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "debug-test": "mocha --inspect-brk"
   },
   "author": "George Pittarelli <g@gjp.cc>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "babel-core": "^6.20.0",
     "babel-plugin-syntax-jsx": "^6.18.0",
+    "babel-plugin-tester": "^6.0.1",
     "babel-plugin-transform-es2015-destructuring": "^6.23.0",
     "babel-plugin-transform-export-extensions": "^6.22.0",
     "mocha": "3.4.2"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   },
   "author": "George Pittarelli <g@gjp.cc>",
   "license": "MIT",
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "devDependencies": {
     "babel-core": "^6.20.0",
     "babel-plugin-syntax-jsx": "^6.18.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "babel-core": "^6.20.0",
     "babel-plugin-syntax-jsx": "^6.18.0",
     "babel-plugin-tester": "^6.0.1",
-    "babel-plugin-transform-es2015-destructuring": "^6.23.0",
     "babel-plugin-transform-export-extensions": "^6.22.0",
     "mocha": "3.4.2"
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-transform-resolve-wildcard-import",
   "version": "0.1.1",
-  "description": "Transforms wildcard imports (import * as x from 'y';x.a();) to member style imports (import {a} from 'y';a();)",
+  "description": "Transforms wildcard imports (import * as x from 'y'; x.a();) to member style imports (import {a} from 'y'; a();).",
   "keywords": [
     "babel",
     "plugin",
@@ -11,6 +11,7 @@
     "resolve"
   ],
   "main": "src/index.js",
+  "files": ["src/*.js"],
   "repository": {
     "type": "git",
     "url": "https://github.com/gpittarelli/babel-plugin-transform-resolve-wildcard-import.git"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   "license": "MIT",
   "devDependencies": {
     "babel-core": "^6.20.0",
+    "babel-plugin-syntax-jsx": "^6.18.0",
+    "babel-plugin-transform-export-extensions": "^6.22.0",
     "mocha": "3.4.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 var flatten = function (arr) {
-  return [].concat.apply([], arr);
+  if (arr.length === 0) return arr;
+  return Array.prototype.concat.apply([], arr);
 }
 
 function shouldTransform(importName, opts) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-var $pluginName = 'transform-resolve-wildcard-imports';
+const $pluginName = 'transform-resolve-wildcard-imports';
 
 function flatten(arr) {
   if (arr.length === 0) return arr;
@@ -67,7 +67,7 @@ function checkDestructure(t, localName, container) {
 }
 
 function extractUsedPropKeys(t, localName, path) {
-  var container = path.container;
+  const container = path.container;
 
   switch (true) {
     // Member access...
@@ -91,17 +91,17 @@ function getUsedPropKeys(t, localName, scope) {
   // Re-crawl the scope to resolve UIDs to proper bindings.
   if (scope.uids[localName]) scope.crawl();
 
-  var binding = scope.getBinding(localName);
+  const binding = scope.getBinding(localName);
 
   if (!binding) return [];
   if (binding.constantViolations.length > 0) return [];
 
-  var referencePaths = binding.referencePaths,
+  const referencePaths = binding.referencePaths,
     len = referencePaths.length,
     result = [];
 
-  for (var i = 0; i < len; i++) {
-    var propKeys = extractUsedPropKeys(t, localName, referencePaths[i]);
+  for (let i = 0; i < len; i++) {
+    const propKeys = extractUsedPropKeys(t, localName, referencePaths[i]);
 
     // Abort and return an empty array if `extractUsedPropKeys`
     // could not be applied to the input.
@@ -128,27 +128,26 @@ function setupState() {
 }
 
 function ImportDeclaration(t, supportsESM, path, state) {
-  var node = path.node,
-    scope = path.scope,
-    whitelist = state.get($pluginName);
+  const { node, scope } = path;
+  const whitelist = state.get($pluginName);
 
   if (!shouldTransform(node.source.value, whitelist)) return;
 
   node.specifiers = flatten(node.specifiers.map((spec) => {
     if (!t.isImportNamespaceSpecifier(spec)) return spec;
 
-    var usedPropKeys = getUsedPropKeys(t, spec.local.name, scope);
+    const usedPropKeys = getUsedPropKeys(t, spec.local.name, scope);
 
     if (usedPropKeys.length === 0) return spec;
 
-    var newSpecs = [],
+    const newSpecs = [],
       props = [],
       newIdents = Object.create(null);
 
     usedPropKeys.forEach((name) => {
       if (newIdents[name] != null) return;
 
-      var newIdent = newIdents[name] = scope.generateUidIdentifier(name);
+      const newIdent = newIdents[name] = scope.generateUidIdentifier(name);
       newSpecs.push(
         t.importSpecifier(newIdent, t.identifier(name))
       );

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-var flatten = function (arr) {
+function flatten(arr) {
   if (arr.length === 0) return arr;
   return Array.prototype.concat.apply([], arr);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -146,15 +146,13 @@ function ImportDeclaration(t, path, state) {
       newIdents = Object.create(null);
 
     usedPropKeys.forEach((name) => {
-      if (newIdents[name]) {
-        newIdent = newIdents[name];
-      } else {
-        newIdent = newIdents[name] = scope.generateUidIdentifier(name);
-        newSpecs.push(
-          t.importSpecifier(newIdent, t.identifier(name))
-        );
-        props.push(t.objectProperty(t.identifier(name), newIdent));
-      }
+      if (newIdents[name] != null) return;
+
+      var newIdent = newIdents[name] = scope.generateUidIdentifier(name);
+      newSpecs.push(
+        t.importSpecifier(newIdent, t.identifier(name))
+      );
+      props.push(t.objectProperty(t.identifier(name), newIdent));
     });
 
     if (props.length > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -37,11 +37,9 @@ function checkDestructure(t, localName, container) {
       return false;
 
     default:
-      return container.id.properties.every(function (prop) {
-        // Non-computed property keys can be both an identifier
-        // and a literal-value.  Only identifiers are supported.
-        return t.isIdentifier(prop.key);
-      });
+      // Non-computed property keys can be both an identifier
+      // and a literal-value.  Only identifiers are supported.
+      return container.id.properties.every(p => t.isIdentifier(p.key));
   }
 }
 
@@ -56,9 +54,7 @@ function extractUsedPropKeys(t, localName, path) {
 
     // Object destructuring assignment...
     case checkDestructure(t, localName, container):
-      return container.id.properties.map(function(prop) {
-        return prop.key.name;
-      });
+      return container.id.properties.map(p => p.key.name);
 
     // Anything else does not apply to this function.
     default:
@@ -96,7 +92,7 @@ function ImportDeclaration(t, path, state) {
     return;
   }
 
-  node.specifiers = flatten(node.specifiers.map(function (spec) {
+  node.specifiers = flatten(node.specifiers.map((spec) => {
     if (!t.isImportNamespaceSpecifier(spec)) {
       return spec;
     }
@@ -122,7 +118,7 @@ function ImportDeclaration(t, path, state) {
       props = [],
       newIdents = Object.create(null);
 
-    usedPropKeys.forEach(function (name) {
+    usedPropKeys.forEach((name) => {
       if (newIdents[name]) {
         newIdent = newIdents[name];
       } else {

--- a/src/index.js
+++ b/src/index.js
@@ -41,8 +41,24 @@ function ImportDeclaration(t, path, state) {
       return spec;
     }
 
-    var binding = scope.getBinding(spec.local.name),
-      usages = binding.referencePaths,
+    var localName = spec.local.name;
+
+    if (!scope.hasBinding(localName)) {
+      return spec;
+    }
+
+    if (scope.uids[localName]) {
+      // Re-crawl the scope to resolve UIDs to proper bindings.
+      scope.crawl();
+    }
+
+    var binding = scope.getBinding(localName);
+
+    if (!binding) {
+      return spec;
+    }
+
+    var usages = binding.referencePaths,
       noShadows = binding.constantViolations.length === 0;
 
     var canReplace = noShadows && usages.every(function (u) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,66 @@
 const $pluginName = 'transform-resolve-wildcard-imports';
 
+class UidMap {
+
+  constructor(types, scope) {
+    this._types = types;
+    this._scope = scope;
+    this._map = new Map();
+  }
+
+  get(id, alias) {
+    const name = this._resolveName(id);
+    if (!name) throw new Error(`cannot resolve a name from: ${id.toString()}`);
+
+    let uid = this._map.get(name);
+    if (uid) return uid;
+
+    uid = this._resolveUid(name, this._resolveName(alias));
+    this._map.set(name, uid);
+
+    return uid;
+  }
+
+  hasConstantViolations(id) {
+    const name = this._resolveName(id);
+    if (!name) return false;
+
+    const binding = this._scope.getBinding(name);
+    return binding.constantViolations.length > 0;
+  }
+
+  getSpecifiers() {
+    const result = [];
+
+    for (const [name, uid] of this._map) {
+      result.push(this._types.importSpecifier(
+        this._types.identifier(uid),
+        this._types.identifier(name)
+      ));
+    }
+
+    return result;
+  }
+
+  _resolveName(id) {
+    switch (true) {
+      case typeof id === 'string':
+        return id;
+      case this._types.isIdentifier(id):
+      case this._types.isJSXIdentifier(id):
+        return id.name;
+      default:
+        return null;
+    }
+  }
+
+  _resolveUid(name, alias) {
+    if (alias) return alias;
+    return this._scope.generateUid(name);
+  }
+
+}
+
 function flatten(arr) {
   if (arr.length === 0) return arr;
   return Array.prototype.concat.apply([], arr);
@@ -36,24 +97,26 @@ function shouldTransform(importName, whitelist) {
   });
 }
 
-function checkDestructure(t, localName, container) {
+function checkDestructure(t, localName, parent) {
   switch (true) {
-    case !t.isVariableDeclarator(container):
-    case !t.isObjectPattern(container.id):
-    case !t.isIdentifier(container.init):
-    case container.init.name !== localName:
+    case !t.isVariableDeclarator(parent):
+    case !t.isObjectPattern(parent.id):
+    case !t.isIdentifier(parent.init):
+    case parent.init.name !== localName:
     // Decorators are not supported.
-    case isDecorated(container.id):
+    case isDecorated(parent.id):
       return false;
 
     default:
-      return container.id.properties.every((prop) => {
+      return parent.id.properties.every((prop) => {
         switch (true) {
           // Only property-based destructuring is supported.
           case !t.isObjectProperty(prop):
           // Non-computed property keys can be both an identifier
           // and a literal-value.  Only identifiers are supported.
           case !t.isIdentifier(prop.key):
+          // Default values are not supported.
+          case t.isAssignmentPattern(prop.value):
           // Decorators are not supported.
           case isDecorated(prop):
           case isDecorated(prop.key):
@@ -66,18 +129,61 @@ function checkDestructure(t, localName, container) {
   }
 }
 
-function extractUsedPropKeys(t, localName, path) {
-  const container = path.container;
+const xforms = {
+  MemberExpression(t, path, uidMap) {
+    const uid = uidMap.get(path.node.property);
+    path.replaceWith(t.identifier(uid));
+  },
+  JSXMemberExpression(t, path, uidMap) {
+    const uid = uidMap.get(path.node.property);
+    path.replaceWith(t.jSXIdentifier(uid));
+  },
+  VariableDeclarator(t, path, uidMap) {
+    let varDeclarators = path.node.id.properties
+      .map((prop) => {
+        const { key, value } = prop;
+        const hasViolation = uidMap.hasConstantViolations(value);
+        const uid = uidMap.get(key, hasViolation ? null : value);
+
+        switch (true) {
+          case !t.isIdentifier(value):
+          case uid !== value.name:
+            return t.variableDeclarator(value, t.identifier(uid));
+          default:
+            return void 0;
+        }
+      })
+      .filter(Boolean);
+
+    const parent = path.parentPath;
+
+    if (parent.node.declarations.length > 1) {
+      path.remove();
+      varDeclarators = varDeclarators.concat(parent.node.declarations);
+    }
+
+    if (varDeclarators.length > 0)
+      parent.replaceWith(t.variableDeclaration(parent.node.kind, varDeclarators));
+    else
+      parent.remove();
+  }
+};
+
+function extractTransformFn(t, localName, path) {
+  const parent = path.parent;
 
   switch (true) {
     // Member access...
-    case t.isMemberExpression(container) && !container.computed:
-    case t.isJSXMemberExpression(container):
-      return container.property.name;
+    case t.isMemberExpression(parent) && !parent.computed:
+      return xforms.MemberExpression.bind(null, t, path.parentPath);
+    
+    // JSX member access...
+    case t.isJSXMemberExpression(parent):
+      return xforms.JSXMemberExpression.bind(null, t, path.parentPath);
 
     // Object destructuring assignment...
-    case checkDestructure(t, localName, container):
-      return container.id.properties.map(p => p.key.name);
+    case checkDestructure(t, localName, parent):
+      return xforms.VariableDeclarator.bind(null, t, path.parentPath);
 
     // Anything else does not apply to this function.
     default:
@@ -85,7 +191,7 @@ function extractUsedPropKeys(t, localName, path) {
   }
 }
 
-function getUsedPropKeys(t, localName, scope) {
+function getTransforms(t, localName, scope) {
   if (!scope.hasBinding(localName)) return [];
 
   // Re-crawl the scope to resolve UIDs to proper bindings.
@@ -101,16 +207,16 @@ function getUsedPropKeys(t, localName, scope) {
     result = [];
 
   for (let i = 0; i < len; i++) {
-    const propKeys = extractUsedPropKeys(t, localName, referencePaths[i]);
+    const xformFn = extractTransformFn(t, localName, referencePaths[i]);
 
     // Abort and return an empty array if `extractUsedPropKeys`
     // could not be applied to the input.
-    if (propKeys == null) return [];
+    if (xformFn == null) return [];
 
-    result.push(propKeys);
+    result.push(xformFn);
   }
 
-  return flatten(result);
+  return result;
 }
 
 function setupState() {
@@ -136,33 +242,13 @@ function ImportDeclaration(t, supportsESM, path, state) {
   node.specifiers = flatten(node.specifiers.map((spec) => {
     if (!t.isImportNamespaceSpecifier(spec)) return spec;
 
-    const usedPropKeys = getUsedPropKeys(t, spec.local.name, scope);
+    const transformations = getTransforms(t, spec.local.name, scope);
+    if (transformations.length === 0) return spec;
 
-    if (usedPropKeys.length === 0) return spec;
+    const uidMap = new UidMap(t, scope);
+    transformations.forEach(xformFn => xformFn(uidMap));
 
-    const newSpecs = [],
-      props = [],
-      newIdents = Object.create(null);
-
-    usedPropKeys.forEach((name) => {
-      if (newIdents[name] != null) return;
-
-      const newIdent = newIdents[name] = scope.generateUidIdentifier(name);
-      newSpecs.push(
-        t.importSpecifier(newIdent, t.identifier(name))
-      );
-      props.push(t.objectProperty(t.identifier(name), newIdent));
-    });
-
-    if (props.length > 0) {
-      path.insertAfter(
-        t.variableDeclaration(supportsESM ? 'const' : 'var', [
-          t.variableDeclarator(spec.local, t.objectExpression(props))
-        ])
-      );
-    }
-
-    return newSpecs;
+    return uidMap.getSpecifiers();
   }));
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -61,11 +61,6 @@ class UidMap {
 
 }
 
-function flatten(arr) {
-  if (arr.length === 0) return arr;
-  return Array.prototype.concat.apply([], arr);
-}
-
 function isDecorated(node) {
   return node.decorators && node.decorators.length > 0;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -233,7 +233,7 @@ function setupState() {
   }));
 }
 
-function ImportDeclaration(t, supportsESM, path, state) {
+function ImportDeclaration(t, path, state) {
   const { node, scope } = path;
   const whitelist = state.get($pluginName);
 
@@ -252,17 +252,12 @@ function ImportDeclaration(t, supportsESM, path, state) {
   }));
 }
 
-function supportsESM(api) {
-  if (typeof api.caller !== 'function') return false;
-  return api.caller(caller => Boolean(caller && caller.supportsStaticESM));
-}
-
 module.exports = function resolveWildcardImports(api) {
   return {
     name: $pluginName,
     pre: setupState,
     visitor: {
-      ImportDeclaration: ImportDeclaration.bind(null, api.types, supportsESM(api))
+      ImportDeclaration: ImportDeclaration.bind(null, api.types)
     }
   };
 };

--- a/test/.babelrc
+++ b/test/.babelrc
@@ -1,7 +1,6 @@
 {
     "plugins": [
         "syntax-jsx",
-        "transform-es2015-destructuring",
         "transform-export-extensions"
     ]
 }

--- a/test/.babelrc
+++ b/test/.babelrc
@@ -1,0 +1,7 @@
+{
+    "plugins": [
+        "syntax-jsx",
+        "transform-es2015-destructuring",
+        "transform-export-extensions"
+    ]
+}

--- a/test/tests.js
+++ b/test/tests.js
@@ -265,6 +265,14 @@ pluginTester({
         import * as x from 'y';
         var [a, b] = x;
       `,
+    },
+
+    'should not transform when a de-opt occurs after a successful transform': {
+      code: `
+        import * as x from 'y';
+        var { a, b: { t, ['u']: you } } = x;
+        var [c, d] = x;
+      `,
     }
   }
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -70,11 +70,18 @@ pluginTester({
       `,
     },
 
-    'should not transform if any non-property usages': {
+    'should not transform when bracketed property access syntax is used': {
       code: `
         import * as x from 'y';
         var a = 'a';
         x[a]();
+      `,
+    },
+
+    'should not transform in the case of direct usage': {
+      code: `
+        import * as x from 'y';
+        console.log(Object.keys(x));
       `,
     },
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -8,6 +8,7 @@ function transform(code, opts) {
     babelrc: false,
     plugins: [
       'syntax-jsx',
+      'transform-es2015-destructuring',
       'transform-export-extensions',
       opts ? [plugin, opts] : plugin
     ]
@@ -88,6 +89,44 @@ describe('wildcard import transformations', function() {
     assert.equal(transform(orig),
       "import * as _x from 'y';\n" +
       "export { _x as x };"
+    );
+  });
+
+  it('should transform from destructuring assignments', function() {
+    var orig = "import * as x from 'y';var { a, b, c } = x;",
+      out = transform(orig);
+
+    assert.equal(transform(orig),
+      "import { a as _a, b as _b, c as _c } from 'y';var x = {\n" +
+      "  a: _a,\n" +
+      "  b: _b,\n" +
+      "  c: _c\n" +
+      "};\n" +
+      "var a = x.a,\n" +
+      "    b = x.b,\n" +
+      "    c = x.c;"
+    );
+  });
+
+  it('should not transform from destructuring assignments with literal properties', function() {
+    var orig = "import * as x from 'y';var { ['1a']: a, b, c } = x;",
+      out = transform(orig);
+
+    assert.equal(out,
+      "import * as x from 'y';var a = x['1a'],\n" +
+      "    b = x.b,\n" +
+      "    c = x.c;"
+    );
+  });
+
+  it('should not transform from destructuring assignments with computed properties', function() {
+    var orig = "import * as x from 'y';var { ['A'.toLowerCase()]: a, b, c } = x;",
+      out = transform(orig);
+
+    assert.equal(out,
+      "import * as x from 'y';var a = x['A'.toLowerCase()],\n" +
+      "    b = x.b,\n" +
+      "    c = x.c;"
     );
   });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -128,9 +128,7 @@ pluginTester({
           b: _b,
           c: _c
         };
-        var a = x.a,
-            b = x.b,
-            c = x.c;
+        var { a, b, c } = x;
       `,
     },
 
@@ -139,24 +137,12 @@ pluginTester({
         import * as x from 'y';
         var { ['1a']: a, b, c } = x;
       `,
-      output: `
-        import * as x from 'y';
-        var a = x['1a'],
-            b = x.b,
-            c = x.c;
-      `,
     },
 
     'should not transform from destructuring assignments with computed properties': {
       code: `
         import * as x from 'y';
         var { ['A'.toLowerCase()]: a, b, c } = x;
-      `,
-      output: `
-        import * as x from 'y';
-        var a = x['A'.toLowerCase()],
-            b = x.b,
-            c = x.c;
       `,
     }
   }

--- a/test/tests.js
+++ b/test/tests.js
@@ -239,6 +239,32 @@ pluginTester({
         import * as x from 'y';
         var { ['A'.toLowerCase()]: a, b, c } = x;
       `,
+    },
+
+    'should not transform from destructuring assignments with default values': {
+      code: `
+        import * as x from 'y';
+        var { a, b, c = 'see' } = x;
+      `,
+    },
+
+    'should not transform from destructuring assignments with object-spread pattern': {
+      babelOptions: {
+        parserOpts: {
+          plugins: ['objectRestSpread']
+        }
+      },
+      code: `
+        import * as x from 'y';
+        var { a, b, ...rest } = x;
+      `,
+    },
+
+    'should not transform from destructuring assignments with array pattern': {
+      code: `
+        import * as x from 'y';
+        var [a, b] = x;
+      `,
     }
   }
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -6,10 +6,11 @@ function transform(code, opts) {
 
   return babel.transform(code, {
     babelrc: false,
-    plugins: [opts ? [plugin, opts] : plugin],
-    parserOpts: {
-      plugins: ['*']
-    }
+    plugins: [
+      'syntax-jsx',
+      'transform-export-extensions',
+      opts ? [plugin, opts] : plugin
+    ]
   }).code;
 }
 
@@ -77,6 +78,16 @@ describe('wildcard import transformations', function() {
       "  A: _A\n" +
       "};\n" +
       "<x.A></x.A>;"
+    );
+  });
+
+  it('should not fail when used with `transform-export-extensions`', function() {
+    var orig = "export * as x from 'y';",
+      out = transform(orig);
+
+    assert.equal(transform(orig),
+      "import * as _x from 'y';\n" +
+      "export { _x as x };"
     );
   });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -52,6 +52,24 @@ pluginTester({
       `,
     },
 
+    'should handle complex wildcard case': {
+      code: `
+        import defaultExport, * as x from 'y';
+        x.a();
+        x.b();
+        x.c.d();
+        defaultExport();
+      `,
+      output: `
+        import defaultExport from 'y';
+        import { a as _a, b as _b, c as _c } from 'y';
+        _a();
+        _b();
+        _c.d();
+        defaultExport();
+      `,
+    },
+
     'should not transform if any non-property usages': {
       code: `
         import * as x from 'y';

--- a/test/tests.js
+++ b/test/tests.js
@@ -188,6 +188,45 @@ pluginTester({
       `,
     },
 
+    'should transform from duplicated destructuring assignments, assigned intermediate': {
+      code: `
+        import * as x from 'y';
+        var { a, b } = x;
+        var { b: { t, u } } = x;
+        var { b: { v } } = x;
+      `,
+      output: `
+        import { a, b } from 'y';
+        var { t, u } = b;
+        var { v } = b;
+      `,
+    },
+
+    'should transform from duplicated destructuring assignments, unassigned intermediate': {
+      code: `
+        import * as x from 'y';
+        var { a, b: { t, u } } = x;
+        var { b: { v } } = x;
+      `,
+      output: `
+        import { a, b as _b } from 'y';
+        var { t, u } = _b;
+        var { v } = _b;
+      `,
+    },
+
+    'should transform from duplicated destructuring assignments, alternative identifier': {
+      code: `
+        import * as x from 'y';
+        var { a, b } = x;
+        var { b: bee } = x;
+      `,
+      output: `
+        import { a, b } from 'y';
+        var bee = b;
+      `,
+    },
+
     'should not transform from destructuring assignments with literal properties': {
       code: `
         import * as x from 'y';

--- a/test/tests.js
+++ b/test/tests.js
@@ -172,11 +172,11 @@ pluginTester({
     'should transform from destructuring assignments, nested usage': {
       code: `
         import * as x from 'y';
-        var { a, b: { t, u }, c: { v: vee } } = x;
+        var { a, b: { t, ['u']: you }, c: { v: vee } } = x;
       `,
       output: `
         import { a, b as _b, c as _c } from 'y';
-        var { t, u } = _b,
+        var { t, ['u']: you } = _b,
             { v: vee } = _c;
       `,
     },


### PR DESCRIPTION
I did some work on this plugin for my own projects and I believe some of my changes would be beneficial to others.

This pull-request adds one major feature and a few smaller changes here and there.  New tests have been created to add coverage for the changes.

My apologies for creating such a large and transformative pull-request.  The decision to contribute these changes back only came after I made significant changes.

# Summary of Changes

## Support for Destructuring Assignments

Destructuring assignments can now be transformed into named-imports as well, as long as they follow some restrictions.  These restrictions are outlined in the `de-optimizations` section of the updated readme.

Input:

```javascript
import * as x from 'y';
const { a, b: { ['c']: see } } = x;
a();
see();
```

Equivalent output:

```javascript
import { a, b as _b } from 'y';
const { ['c']: see } = _b;
a();
see();
```

## Removed Need for Intermediate Object

An intermediate object is no longer generated with these changes.  The variables are defined directly in the `import` statement, which was described as the "ideal case" originally.  Destructuring assignments will import with the desired alias, when possible, and generated UIDs otherwise.

## Fixes Issue Related to `transform-export-extensions` Plugin

I found that this plugin could fail if it was used with the [`transform-export-extensions`](https://babeljs.io/docs/en/6.26.3/babel-plugin-transform-export-extensions) plugin, as well as the Babel 7 equivalent, [`transform-export-namespace`](https://www.npmjs.com/package/babel-plugin-transform-export-namespace).

When these plugins generate identifiers for the `export { ... } from` syntax, those bindings aren't reflected in the scope.  The scope needs to be re-crawled in order to ensure the new bindings are made available.

This issue is fixed by this pull-request.

## Adds Better Support for Programmatic Options

Before, the `only` option supported only strings which would be treated as regular-expression patterns.  If using programmatic options with Babel, or a `.babelrc.js` file with Babel 7, full regular-expression instances and functions can be provided as well.

## Tests Now Use Babel Plugin Tester

Considered the standard for testing simpler Babel plugins, [Babel Plugin Tester](https://github.com/babel-utils/babel-plugin-tester) should make creating and following tests easier, especially by future contributors who are already familiar with it.

Falling back to normal Mocha tests is still possible, when needed.

# Drawbacks

## Requires Node 6.0 or Greater

Some of the code was written to rely on features provided by Node 6.0 and higher; this could break builds of current users if they are still using older Node versions.

As such, if this pull-request is accepted, **it should probably be distributed as a new major version**.

## More Complicated Code

Adding destructuring assignments and removing the need for the intermediate object did increase the complexity of the code significantly.

An attempt was made to try and keep the tests and application of the different types of transforms uniform, but the size of the code is much larger and more complex than the previous version of the plugin.

The addition of the `UidMap` class, which tracks the mappings of UIDs and aliases to the name of the desired import, is probably the biggest source of new complexity.